### PR TITLE
feat: CLIインターフェースを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ source venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt
+
+# Install the CLI tool (optional)
+pip install -e .
 ```
 
 ## Quick Start
@@ -92,6 +95,40 @@ llm-as-a-judge/
 └── CLAUDE.md           # Development guidelines
 ```
 
+## Command Line Interface
+
+After installing with `pip install -e .`, you can use the `llm-judge` command:
+
+### Evaluate a Document
+
+```bash
+# Evaluate a document from file
+llm-judge evaluate tests/rubric.json -f document.txt
+
+# Evaluate from stdin
+echo "Your document text here" | llm-judge evaluate tests/rubric.json
+
+# Output as JSON
+llm-judge evaluate tests/rubric.json -f document.txt -o json
+```
+
+### Export Criteria
+
+```bash
+# Export criteria to XML (stdout)
+llm-judge export tests/rubric.json
+
+# Export to file
+llm-judge export tests/rubric.json -o criteria.xml
+```
+
+### Show Criteria
+
+```bash
+# Display criteria in human-readable format
+llm-judge show tests/rubric.json
+```
+
 ## Testing
 
 Run the test suite:
@@ -113,10 +150,10 @@ For detailed API documentation and usage examples, see [API.md](API.md).
 
 ## Future Enhancements
 
+- [x] CLI interface
 - [ ] Real LLM API integration (OpenAI, Anthropic)
 - [ ] Batch evaluation for multiple documents
 - [ ] Evaluation result export (JSON/CSV)
-- [ ] CLI interface
 - [ ] Evaluation calibration features
 - [ ] Multi-evaluator consensus mechanisms
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,51 @@
+"""Setup script for LLM as a Judge."""
+
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="llm-as-a-judge",
+    version="0.1.0",
+    author="Takuya Kubo",
+    author_email="takuyakubo@example.com",
+    description="A Python framework for evaluating documents using LLMs as judges",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/takuyakubo/llm-as-a-judge",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Text Processing :: Linguistic",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    python_requires=">=3.8",
+    install_requires=[
+        "pydantic>=2.0.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.0.0",
+            "black>=22.0.0",
+            "flake8>=4.0.0",
+            "mypy>=0.990",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "llm-judge=src.cli:main",
+        ],
+    },
+    include_package_data=True,
+    package_data={
+        "": ["*.json"],
+    },
+)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Command Line Interface for LLM as a Judge framework."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .criteria import Criteria
+from .evaluator import Evaluator
+
+
+def evaluate_document(args):
+    """Evaluate a document using the specified rubric."""
+    # Load criteria
+    criteria = Criteria.from_json_file(args.rubric)
+    
+    # Create evaluator (using mock evaluation for now)
+    evaluator = Evaluator(criteria)
+    
+    # Read document
+    if args.file:
+        with open(args.file, 'r', encoding='utf-8') as f:
+            document = f.read()
+    else:
+        # Read from stdin
+        document = sys.stdin.read()
+    
+    if not document.strip():
+        print("Error: Empty document provided", file=sys.stderr)
+        return 1
+    
+    # Evaluate
+    try:
+        result = evaluator.evaluate_document(document)
+        
+        # Output results
+        if args.output_format == 'json':
+            # Convert to simple score dict for compatibility
+            score_dict = {score.criterion_name: score.score for score in result.scores}
+            print(json.dumps(score_dict, indent=2))
+        else:  # pretty format
+            print("Evaluation Results:")
+            print("-" * 40)
+            for score in result.scores:
+                print(f"{score.criterion_name}: {score.score}/5")
+            print("-" * 40)
+            total = sum(score.score for score in result.scores)
+            avg = total / len(result.scores)
+            print(f"Total Score: {total}/{len(result.scores) * 5}")
+            print(f"Average: {avg:.2f}/5")
+            
+    except Exception as e:
+        print(f"Error during evaluation: {e}", file=sys.stderr)
+        return 1
+    
+    return 0
+
+
+def export_criteria(args):
+    """Export criteria to XML format."""
+    # Load criteria
+    criteria = Criteria.from_json_file(args.rubric)
+    
+    # Export to XML
+    xml_output = criteria.to_xml()
+    
+    # Output
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(xml_output)
+        print(f"Criteria exported to {args.output}")
+    else:
+        print(xml_output)
+    
+    return 0
+
+
+def show_criteria(args):
+    """Display criteria in human-readable format."""
+    # Load criteria
+    criteria = Criteria.from_json_file(args.rubric)
+    
+    # Display criteria
+    for criterion in criteria.criteria_list:
+        print(f"\n{criterion.name}")
+        print("=" * len(criterion.name))
+        print(f"Description: {criterion.description}")
+        print("\nScoring Levels:")
+        for level in criterion.levels:
+            print(f"  {level.score}: {level.rule}")
+    
+    return 0
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="LLM as a Judge - Document evaluation framework",
+        epilog="For more information, visit: https://github.com/takuyakubo/llm-as-a-judge"
+    )
+    
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+    subparsers.required = True
+    
+    # Evaluate command
+    eval_parser = subparsers.add_parser('evaluate', help='Evaluate a document')
+    eval_parser.add_argument(
+        'rubric',
+        help='Path to rubric JSON file'
+    )
+    eval_parser.add_argument(
+        '-f', '--file',
+        help='Document file to evaluate (if not provided, reads from stdin)'
+    )
+    eval_parser.add_argument(
+        '-o', '--output-format',
+        choices=['pretty', 'json'],
+        default='pretty',
+        help='Output format (default: pretty)'
+    )
+    eval_parser.set_defaults(func=evaluate_document)
+    
+    # Export command
+    export_parser = subparsers.add_parser('export', help='Export criteria to XML')
+    export_parser.add_argument(
+        'rubric',
+        help='Path to rubric JSON file'
+    )
+    export_parser.add_argument(
+        '-o', '--output',
+        help='Output file path (if not provided, prints to stdout)'
+    )
+    export_parser.set_defaults(func=export_criteria)
+    
+    # Show command
+    show_parser = subparsers.add_parser('show', help='Display criteria in readable format')
+    show_parser.add_argument(
+        'rubric',
+        help='Path to rubric JSON file'
+    )
+    show_parser.set_defaults(func=show_criteria)
+    
+    # Parse arguments
+    args = parser.parse_args()
+    
+    # Execute command
+    try:
+        sys.exit(args.func(args))
+    except FileNotFoundError as e:
+        print(f"Error: File not found - {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/criteria.py
+++ b/src/criteria.py
@@ -12,8 +12,9 @@ class Criterion(BaseModel):
     levels: list[Level]
 
 class Criteria:
-    def __init__(self) -> None:
-        self.criteria = []
+    def __init__(self, criteria_list: list[Criterion] | None = None) -> None:
+        self.criteria = criteria_list or []
+        self.criteria_list = self.criteria  # Alias for compatibility
 
     def append(self, criterion: Criterion) -> None:
         self.criteria.append(criterion)
@@ -69,6 +70,50 @@ class Criteria:
             criterion = Criterion(
                 name=criterion_data["name"],
                 description=criterion_data.get("description", ""),  # Default to empty string
+                levels=levels
+            )
+            criteria.append(criterion)
+        
+        return criteria
+
+    @classmethod
+    def from_json_file(cls, filepath: str) -> 'Criteria':
+        """Load criteria from a JSON file."""
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return cls.from_json(f.read())
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {
+            "criteria": [
+                {
+                    "name": criterion.name,
+                    "description": criterion.description,
+                    "levels": [
+                        {
+                            "score": level.score,
+                            "rule": level.rule
+                        }
+                        for level in criterion.levels
+                    ]
+                }
+                for criterion in self.criteria
+            ]
+        }
+    
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Criteria':
+        """Create from dictionary representation."""
+        criteria = cls()
+        
+        for criterion_data in data.get("criteria", []):
+            levels = [
+                Level(score=level_data["score"], rule=level_data["rule"])
+                for level_data in criterion_data.get("levels", [])
+            ]
+            criterion = Criterion(
+                name=criterion_data["name"],
+                description=criterion_data.get("description", ""),
                 levels=levels
             )
             criteria.append(criterion)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,248 @@
+"""Tests for CLI module."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+from io import StringIO
+
+from src.cli import evaluate_document, export_criteria, show_criteria, main
+
+
+class TestCLI(unittest.TestCase):
+    """Test cases for CLI functionality."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_rubric = {
+            "criteria": [
+                {
+                    "name": "clarity",
+                    "description": "How clear the text is",
+                    "levels": [
+                        {"score": 5, "rule": "Very clear"},
+                        {"score": 4, "rule": "Clear"},
+                        {"score": 3, "rule": "Somewhat clear"},
+                        {"score": 2, "rule": "Unclear"},
+                        {"score": 1, "rule": "Very unclear"}
+                    ]
+                },
+                {
+                    "name": "accuracy",
+                    "description": "How accurate the content is",
+                    "levels": [
+                        {"score": 5, "rule": "Highly accurate"},
+                        {"score": 4, "rule": "Accurate"},
+                        {"score": 3, "rule": "Mostly accurate"},
+                        {"score": 2, "rule": "Inaccurate"},
+                        {"score": 1, "rule": "Very inaccurate"}
+                    ]
+                }
+            ]
+        }
+        
+        # Create temporary rubric file
+        self.rubric_file = tempfile.NamedTemporaryFile(
+            mode='w', 
+            suffix='.json', 
+            delete=False
+        )
+        json.dump(self.test_rubric, self.rubric_file)
+        self.rubric_file.close()
+        
+    def tearDown(self):
+        """Clean up test fixtures."""
+        os.unlink(self.rubric_file.name)
+        
+    def test_evaluate_document_from_file(self):
+        """Test evaluating document from file."""
+        # Create test document
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("This is a test document for evaluation.")
+            doc_file = f.name
+            
+        try:
+            # Create mock args
+            args = MagicMock()
+            args.rubric = self.rubric_file.name
+            args.file = doc_file
+            args.output_format = 'json'
+            
+            # Capture output
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                result = evaluate_document(args)
+                output = fake_out.getvalue()
+                
+            # Check result
+            self.assertEqual(result, 0)
+            parsed_output = json.loads(output)
+            self.assertIn('clarity', parsed_output)
+            self.assertIn('accuracy', parsed_output)
+            
+        finally:
+            os.unlink(doc_file)
+            
+    def test_evaluate_document_from_stdin(self):
+        """Test evaluating document from stdin."""
+        args = MagicMock()
+        args.rubric = self.rubric_file.name
+        args.file = None
+        args.output_format = 'pretty'
+        
+        # Mock stdin
+        test_input = "This is a test document from stdin."
+        with patch('sys.stdin', StringIO(test_input)):
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                result = evaluate_document(args)
+                output = fake_out.getvalue()
+                
+        # Check result
+        self.assertEqual(result, 0)
+        self.assertIn("Evaluation Results:", output)
+        self.assertIn("clarity:", output)
+        self.assertIn("accuracy:", output)
+        self.assertIn("Total Score:", output)
+        self.assertIn("Average:", output)
+        
+    def test_evaluate_empty_document(self):
+        """Test evaluating empty document."""
+        args = MagicMock()
+        args.rubric = self.rubric_file.name
+        args.file = None
+        args.output_format = 'json'
+        
+        # Mock empty stdin
+        with patch('sys.stdin', StringIO("")):
+            with patch('sys.stderr', new=StringIO()) as fake_err:
+                result = evaluate_document(args)
+                error_output = fake_err.getvalue()
+                
+        # Check error
+        self.assertEqual(result, 1)
+        self.assertIn("Error: Empty document provided", error_output)
+        
+    def test_export_criteria_to_stdout(self):
+        """Test exporting criteria to stdout."""
+        args = MagicMock()
+        args.rubric = self.rubric_file.name
+        args.output = None
+        
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            result = export_criteria(args)
+            output = fake_out.getvalue()
+            
+        # Check result
+        self.assertEqual(result, 0)
+        self.assertIn("<criteria>", output)
+        self.assertIn("<criterion name=\"clarity\">", output)
+        self.assertIn("<criterion name=\"accuracy\">", output)
+        
+    def test_export_criteria_to_file(self):
+        """Test exporting criteria to file."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            output_file = f.name
+            
+        try:
+            args = MagicMock()
+            args.rubric = self.rubric_file.name
+            args.output = output_file
+            
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                result = export_criteria(args)
+                console_output = fake_out.getvalue()
+                
+            # Check result
+            self.assertEqual(result, 0)
+            self.assertIn(f"Criteria exported to {output_file}", console_output)
+            
+            # Check file content
+            with open(output_file, 'r') as f:
+                content = f.read()
+            self.assertIn("<criteria>", content)
+            
+        finally:
+            os.unlink(output_file)
+            
+    def test_show_criteria(self):
+        """Test showing criteria in readable format."""
+        args = MagicMock()
+        args.rubric = self.rubric_file.name
+        
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            result = show_criteria(args)
+            output = fake_out.getvalue()
+            
+        # Check result
+        self.assertEqual(result, 0)
+        self.assertIn("clarity", output)
+        self.assertIn("accuracy", output)
+        self.assertIn("Description: How clear the text is", output)
+        self.assertIn("Scoring Levels:", output)
+        self.assertIn("5: Very clear", output)
+        
+    def test_main_evaluate_command(self):
+        """Test main function with evaluate command."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("Test document")
+            doc_file = f.name
+            
+        try:
+            test_args = [
+                'llm-judge',
+                'evaluate',
+                self.rubric_file.name,
+                '-f', doc_file,
+                '-o', 'json'
+            ]
+            
+            with patch('sys.argv', test_args):
+                with patch('sys.stdout', new=StringIO()) as fake_out:
+                    with patch('sys.exit') as mock_exit:
+                        main()
+                        
+            # Check that exit was called with 0
+            mock_exit.assert_called_once_with(0)
+            
+        finally:
+            os.unlink(doc_file)
+            
+    def test_main_file_not_found(self):
+        """Test main function with non-existent file."""
+        test_args = [
+            'llm-judge',
+            'evaluate',
+            'non_existent_rubric.json'
+        ]
+        
+        with patch('sys.argv', test_args):
+            with patch('sys.stderr', new=StringIO()) as fake_err:
+                with patch('sys.exit') as mock_exit:
+                    main()
+                    
+        # Check that exit was called with 1
+        mock_exit.assert_called_once_with(1)
+        
+    def test_main_show_command(self):
+        """Test main function with show command."""
+        test_args = [
+            'llm-judge',
+            'show',
+            self.rubric_file.name
+        ]
+        
+        with patch('sys.argv', test_args):
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                with patch('sys.exit') as mock_exit:
+                    main()
+                    output = fake_out.getvalue()
+                    
+        # Check output
+        self.assertIn("clarity", output)
+        self.assertIn("accuracy", output)
+        mock_exit.assert_called_once_with(0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -93,8 +93,11 @@ class TestEvaluator(unittest.TestCase):
             else:
                 return "スコア: 4\n理由: 論理的に一貫している\n確信度: 0.8"
         
+        # Create evaluator with custom LLM function
+        evaluator_with_llm = Evaluator(self.criteria, llm_function=mock_llm)
+        
         document = "これは優れた文書です。"
-        result = self.evaluator.evaluate_document(document, llm_function=mock_llm)
+        result = evaluator_with_llm.evaluate_document(document)
         
         self.assertEqual(len(result.scores), 2)
         self.assertEqual(result.model_used, "custom_llm")


### PR DESCRIPTION
## Summary
- コマンドラインインターフェース（CLI）を実装し、`llm-judge`コマンドでドキュメント評価、評価基準のエクスポート・表示が可能になりました
- Future Enhancementsリストの最初のタスクを完了しました

## Changes
### 新規ファイル
- `src/cli.py`: CLIインターフェースの実装
  - `evaluate`: ドキュメントを評価（ファイルまたは標準入力から）
  - `export`: 評価基準をXML形式でエクスポート
  - `show`: 評価基準を人間可読形式で表示
- `setup.py`: パッケージのインストール設定
- `tests/test_cli.py`: CLIのユニットテスト

### 既存ファイルの変更
- `src/criteria.py`: 
  - `from_json_file()`: JSONファイルから評価基準を読み込む
  - `to_dict()`, `from_dict()`: 辞書形式への変換メソッド
  - コンストラクタを更新して`criteria_list`引数をサポート
- `src/evaluator.py`: 
  - コンストラクタで`llm_function`を受け取るように変更
  - `evaluate_document()`に`return_dict`オプションを追加
- `README.md`: CLIの使用方法を追加
- `tests/test_evaluator.py`: テストを新しいAPIに合わせて修正

## Test plan
- [x] 全てのユニットテストがパス（32テスト）
- [x] CLIコマンドの動作確認
  - [x] `llm-judge evaluate`
  - [x] `llm-judge export`
  - [x] `llm-judge show`
- [ ] `pip install -e .`でのインストール確認
- [ ] エンドツーエンドでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)