### PR TITLE
feat: Add batch evaluation functionality for processing multiple documents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pydantic-ai>=0.0.9
 openai>=1.0.0
 anthropic>=0.18.0
 python-dotenv>=1.0.0
+tqdm>=4.65.0
 mkdocs>=1.5.0
 mkdocs-material>=9.0.0
 mkdocs-mermaid2-plugin>=1.0.0

--- a/src/cli.py
+++ b/src/cli.py
@@ -139,6 +139,129 @@ def show_criteria(args):
     return 0
 
 
+def evaluate_batch(args):
+    """Evaluate multiple documents in batch."""
+    # Load environment variables
+    load_dotenv()
+    
+    # Load criteria
+    criteria = Criteria.from_json_file(args.rubric)
+    
+    # Create evaluator
+    if args.mock:
+        # Mock mode - no provider needed
+        evaluator = Evaluator(criteria)
+    else:
+        # Set up LLM provider
+        model_name = args.model
+        if not model_name:
+            # Default models per provider
+            default_models = {
+                'pydantic_ai': os.getenv('DEFAULT_MODEL', 'gpt-4o-mini'),
+                'openai': 'gpt-4o-mini',
+                'anthropic': 'claude-3-5-haiku-latest'
+            }
+            model_name = default_models.get(args.provider, 'gpt-4o-mini')
+        
+        llm_config = LLMConfig(
+            model_name=model_name,
+            temperature=args.temperature,
+            max_tokens=args.max_tokens
+        )
+        
+        try:
+            llm_provider = create_llm_provider(args.provider, llm_config)
+            evaluator = Evaluator(criteria, llm_provider=llm_provider)
+        except Exception as e:
+            print(f"Error: Failed to initialize LLM provider: {e}", file=sys.stderr)
+            print("Hint: Make sure API keys are set in environment variables:", file=sys.stderr)
+            print("  - OpenAI: OPENAI_API_KEY", file=sys.stderr)
+            print("  - Anthropic: ANTHROPIC_API_KEY", file=sys.stderr)
+            sys.exit(1)
+    
+    # Determine input source
+    if args.directory:
+        # Evaluate all files in directory
+        try:
+            results = evaluator.evaluate_directory(
+                args.directory,
+                pattern=args.pattern,
+                recursive=args.recursive,
+                show_progress=not args.no_progress,
+                max_concurrent=args.max_concurrent,
+                output_csv=args.output_csv,
+                include_reasoning=args.verbose
+            )
+        except Exception as e:
+            print(f"Error evaluating directory: {e}", file=sys.stderr)
+            return 1
+    else:
+        # Evaluate list of files
+        if not args.files:
+            print("Error: No files or directory specified", file=sys.stderr)
+            return 1
+        
+        # Read documents from files
+        documents = {}
+        for file_path in args.files:
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    documents[file_path] = f.read()
+            except Exception as e:
+                print(f"Warning: Failed to read {file_path}: {e}", file=sys.stderr)
+        
+        if not documents:
+            print("Error: No documents could be read", file=sys.stderr)
+            return 1
+        
+        try:
+            results = evaluator.evaluate_batch(
+                documents,
+                show_progress=not args.no_progress,
+                max_concurrent=args.max_concurrent,
+                output_csv=args.output_csv,
+                include_reasoning=args.verbose
+            )
+        except Exception as e:
+            print(f"Error during batch evaluation: {e}", file=sys.stderr)
+            return 1
+    
+    # Display summary unless CSV output was specified
+    if not args.output_csv:
+        print(f"\nBatch Evaluation Summary:")
+        print("=" * 60)
+        print(f"Total documents evaluated: {len(results)}")
+        
+        if results:
+            avg_overall = sum(r.overall_score for r in results) / len(results)
+            print(f"Average overall score: {avg_overall:.2f}/5")
+            
+            # Per-criterion averages
+            criterion_scores = {}
+            for result in results:
+                for score in result.scores:
+                    if score.criterion_name not in criterion_scores:
+                        criterion_scores[score.criterion_name] = []
+                    criterion_scores[score.criterion_name].append(score.score)
+            
+            print("\nAverage scores by criterion:")
+            for criterion_name, scores in criterion_scores.items():
+                avg_score = sum(scores) / len(scores)
+                print(f"  {criterion_name}: {avg_score:.2f}/5")
+            
+            if args.verbose:
+                print("\nDetailed results:")
+                for result in results:
+                    print(f"\n{result.document_id}:")
+                    print(f"  Overall: {result.overall_score:.2f}/5")
+                    for score in result.scores:
+                        print(f"  {score.criterion_name}: {score.score}/5 (confidence: {score.confidence:.2f})")
+    else:
+        print(f"Results saved to: {args.output_csv}")
+    
+    return 0
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -221,6 +344,92 @@ def main():
         help='Path to rubric JSON file'
     )
     show_parser.set_defaults(func=show_criteria)
+    
+    # Batch evaluate command
+    batch_parser = subparsers.add_parser('batch', help='Evaluate multiple documents in batch')
+    batch_parser.add_argument(
+        'rubric',
+        help='Path to rubric JSON file'
+    )
+    
+    # Input options (mutually exclusive)
+    input_group = batch_parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        '-d', '--directory',
+        help='Directory containing documents to evaluate'
+    )
+    input_group.add_argument(
+        '-f', '--files',
+        nargs='+',
+        help='List of document files to evaluate'
+    )
+    
+    # Directory options
+    batch_parser.add_argument(
+        '-p', '--pattern',
+        default='*.txt',
+        help='File pattern for directory search (default: *.txt)'
+    )
+    batch_parser.add_argument(
+        '-r', '--recursive',
+        action='store_true',
+        help='Search directory recursively'
+    )
+    
+    # Processing options
+    batch_parser.add_argument(
+        '--max-concurrent',
+        type=int,
+        default=5,
+        help='Maximum concurrent evaluations (default: 5)'
+    )
+    batch_parser.add_argument(
+        '--no-progress',
+        action='store_true',
+        help='Disable progress bar'
+    )
+    
+    # Output options
+    batch_parser.add_argument(
+        '-o', '--output-csv',
+        help='Save results to CSV file'
+    )
+    batch_parser.add_argument(
+        '-m', '--mock',
+        action='store_true',
+        help='Use mock evaluation (for testing)'
+    )
+    batch_parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Show detailed results and include reasoning in CSV'
+    )
+    
+    # LLM provider options
+    batch_parser.add_argument(
+        '--provider',
+        choices=['pydantic_ai', 'openai', 'anthropic'],
+        default='pydantic_ai',
+        help='LLM provider (default: pydantic_ai)'
+    )
+    batch_parser.add_argument(
+        '--model',
+        type=str,
+        help='LLM model name'
+    )
+    batch_parser.add_argument(
+        '--temperature',
+        type=float,
+        default=0.3,
+        help='Generation temperature (default: 0.3)'
+    )
+    batch_parser.add_argument(
+        '--max-tokens',
+        type=int,
+        help='Maximum tokens for generation'
+    )
+    
+    batch_parser.set_defaults(func=evaluate_batch)
     
     # Parse arguments
     args = parser.parse_args()

--- a/tests/test_batch_evaluator.py
+++ b/tests/test_batch_evaluator.py
@@ -1,0 +1,261 @@
+import unittest
+import tempfile
+import os
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from src.criteria import Criteria, Criterion, Level
+from src.evaluator import Evaluator, EvaluationResult, CriterionScore
+
+
+class TestBatchEvaluator(unittest.TestCase):
+    def setUp(self):
+        """Set up test criteria and evaluator"""
+        self.criteria = Criteria()
+        self.criteria.append(Criterion(
+            name="clarity",
+            description="文章の明確さ",
+            levels=[
+                Level(score=5, rule="非常に明確"),
+                Level(score=4, rule="明確"),
+                Level(score=3, rule="普通"),
+                Level(score=2, rule="やや不明確"),
+                Level(score=1, rule="不明確")
+            ]
+        ))
+        self.criteria.append(Criterion(
+            name="coherence",
+            description="論理的一貫性",
+            levels=[
+                Level(score=5, rule="完全に一貫"),
+                Level(score=4, rule="ほぼ一貫"),
+                Level(score=3, rule="部分的に一貫"),
+                Level(score=2, rule="一貫性に欠ける"),
+                Level(score=1, rule="全く一貫性なし")
+            ]
+        ))
+        # Use mock evaluator for tests
+        self.evaluator = Evaluator(self.criteria)
+    
+    def test_evaluate_batch_with_list(self):
+        """Test batch evaluation with list of documents"""
+        documents = [
+            "これは最初のテスト文書です。",
+            "これは二番目のテスト文書です。",
+            "これは三番目のテスト文書です。"
+        ]
+        
+        results = self.evaluator.evaluate_batch(documents, show_progress=False)
+        
+        self.assertEqual(len(results), 3)
+        for i, result in enumerate(results):
+            self.assertEqual(result.document_id, f"doc_{i}")
+            self.assertIsInstance(result, EvaluationResult)
+            self.assertEqual(len(result.scores), 2)  # 2 criteria
+    
+    def test_evaluate_batch_with_dict(self):
+        """Test batch evaluation with dictionary of documents"""
+        documents = {
+            "report_1.txt": "業績報告書の内容です。",
+            "report_2.txt": "技術仕様書の内容です。",
+            "report_3.txt": "提案書の内容です。"
+        }
+        
+        results = self.evaluator.evaluate_batch(documents, show_progress=False)
+        
+        self.assertEqual(len(results), 3)
+        doc_ids = {r.document_id for r in results}
+        self.assertEqual(doc_ids, {"report_1.txt", "report_2.txt", "report_3.txt"})
+    
+    def test_evaluate_batch_with_tuples(self):
+        """Test batch evaluation with list of (id, content) tuples"""
+        documents = [
+            ("doc_A", "文書Aの内容"),
+            ("doc_B", "文書Bの内容"),
+            ("doc_C", "文書Cの内容")
+        ]
+        
+        results = self.evaluator.evaluate_batch(documents, show_progress=False)
+        
+        self.assertEqual(len(results), 3)
+        doc_ids = [r.document_id for r in results]
+        self.assertEqual(doc_ids, ["doc_A", "doc_B", "doc_C"])
+    
+    def test_evaluate_batch_csv_output(self):
+        """Test batch evaluation with CSV output"""
+        documents = {
+            "test1.txt": "テスト文書1",
+            "test2.txt": "テスト文書2"
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            csv_path = f.name
+        
+        try:
+            results = self.evaluator.evaluate_batch(
+                documents, 
+                show_progress=False,
+                output_csv=csv_path,
+                include_reasoning=True
+            )
+            
+            # Check CSV file was created
+            self.assertTrue(os.path.exists(csv_path))
+            
+            # Read and verify CSV content
+            with open(csv_path, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+                
+                # Should have 4 rows (2 documents × 2 criteria)
+                self.assertEqual(len(rows), 4)
+                
+                # Check headers
+                expected_headers = {'document_id', 'timestamp', 'model_used', 
+                                  'criterion_name', 'score', 'confidence', 
+                                  'reasoning', 'overall_score'}
+                self.assertEqual(set(reader.fieldnames), expected_headers)
+                
+                # Verify document IDs
+                doc_ids = {row['document_id'] for row in rows}
+                self.assertEqual(doc_ids, {"test1.txt", "test2.txt"})
+                
+        finally:
+            if os.path.exists(csv_path):
+                os.unlink(csv_path)
+    
+    def test_evaluate_directory(self):
+        """Test evaluating all documents in a directory"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create test files
+            test_files = {
+                "doc1.txt": "第一の文書の内容です。",
+                "doc2.txt": "第二の文書の内容です。",
+                "doc3.txt": "第三の文書の内容です。",
+                "ignore.pdf": "This should be ignored"
+            }
+            
+            for filename, content in test_files.items():
+                with open(os.path.join(tmpdir, filename), 'w', encoding='utf-8') as f:
+                    f.write(content)
+            
+            # Evaluate directory
+            results = self.evaluator.evaluate_directory(
+                tmpdir,
+                pattern="*.txt",
+                show_progress=False
+            )
+            
+            # Should only process .txt files
+            self.assertEqual(len(results), 3)
+            
+            # Check document IDs contain file paths
+            doc_ids = {r.document_id for r in results}
+            for doc_id in doc_ids:
+                self.assertTrue(doc_id.endswith('.txt'))
+                self.assertIn('doc', doc_id)
+    
+    def test_evaluate_directory_recursive(self):
+        """Test recursive directory evaluation"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create subdirectory
+            subdir = os.path.join(tmpdir, "subdir")
+            os.makedirs(subdir)
+            
+            # Create files in main and subdirectory
+            files = {
+                os.path.join(tmpdir, "main.txt"): "メインディレクトリの文書",
+                os.path.join(subdir, "sub.txt"): "サブディレクトリの文書"
+            }
+            
+            for filepath, content in files.items():
+                with open(filepath, 'w', encoding='utf-8') as f:
+                    f.write(content)
+            
+            # Non-recursive should only find main.txt
+            results = self.evaluator.evaluate_directory(
+                tmpdir,
+                pattern="*.txt",
+                recursive=False,
+                show_progress=False
+            )
+            self.assertEqual(len(results), 1)
+            
+            # Recursive should find both files
+            results = self.evaluator.evaluate_directory(
+                tmpdir,
+                pattern="*.txt",
+                recursive=True,
+                show_progress=False
+            )
+            self.assertEqual(len(results), 2)
+    
+    def test_evaluate_batch_with_custom_llm(self):
+        """Test batch evaluation with custom LLM function"""
+        def mock_llm(prompt):
+            # Return different scores based on document content
+            if "優秀" in prompt:
+                return "スコア: 5\n理由: 優秀な文書\n確信度: 0.95"
+            elif "良好" in prompt:
+                return "スコア: 4\n理由: 良好な文書\n確信度: 0.85"
+            else:
+                return "スコア: 3\n理由: 標準的な文書\n確信度: 0.75"
+        
+        evaluator_with_llm = Evaluator(self.criteria, llm_function=mock_llm)
+        
+        documents = {
+            "excellent.txt": "これは優秀な文書です。",
+            "good.txt": "これは良好な文書です。",
+            "standard.txt": "これは標準的な文書です。"
+        }
+        
+        results = evaluator_with_llm.evaluate_batch(documents, show_progress=False)
+        
+        # Check that different documents got different scores
+        result_map = {r.document_id: r for r in results}
+        
+        excellent_result = result_map["excellent.txt"]
+        good_result = result_map["good.txt"]
+        standard_result = result_map["standard.txt"]
+        
+        # Verify scores match our mock LLM logic
+        self.assertGreater(excellent_result.overall_score, good_result.overall_score)
+        self.assertGreater(good_result.overall_score, standard_result.overall_score)
+    
+    def test_evaluate_batch_error_handling(self):
+        """Test error handling for invalid inputs"""
+        # Empty list
+        with self.assertRaises(ValueError):
+            self.evaluator.evaluate_batch([])
+        
+        # Invalid directory
+        with self.assertRaises(ValueError):
+            self.evaluator.evaluate_directory("/nonexistent/directory")
+        
+        # Directory with no matching files
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create only non-matching files
+            with open(os.path.join(tmpdir, "test.pdf"), 'w') as f:
+                f.write("PDF content")
+            
+            with self.assertRaises(ValueError):
+                self.evaluator.evaluate_directory(tmpdir, pattern="*.txt")
+    
+    def test_max_concurrent_setting(self):
+        """Test that max_concurrent parameter is respected"""
+        # This is mainly to ensure the parameter is passed correctly
+        # Actual concurrency testing would require mocking async operations
+        documents = ["doc1", "doc2", "doc3", "doc4", "doc5"]
+        
+        results = self.evaluator.evaluate_batch(
+            documents,
+            show_progress=False,
+            max_concurrent=2
+        )
+        
+        self.assertEqual(len(results), 5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add batch evaluation functionality to process multiple documents efficiently
- Implement async/parallel processing with concurrency control
- Add progress tracking and CSV export for batch results

## Changes

### Core Functionality
- **`evaluate_batch()` method**: Process multiple documents with support for:
  - List of documents
  - Dictionary mapping document IDs to content
  - List of (id, content) tuples
- **`evaluate_directory()` method**: Evaluate all documents in a directory with:
  - Pattern matching (e.g., `*.txt`, `*.md`)
  - Recursive directory search option
  - Automatic document discovery

### Performance Features
- Async/parallel processing using `asyncio`
- Configurable concurrency limit (default: 5 concurrent evaluations)
- Progress bar using `tqdm` for visual feedback
- Efficient batch processing for large document sets

### CLI Enhancements
- New `batch` command with options:
  - `-d/--directory`: Evaluate all files in a directory
  - `-f/--files`: Evaluate specific list of files
  - `-p/--pattern`: File pattern for directory search
  - `-r/--recursive`: Recursive directory search
  - `--max-concurrent`: Control parallel execution
  - `-o/--output-csv`: Export results to CSV

### Export and Reporting
- CSV export for batch results with configurable columns
- Summary statistics (average scores per criterion)
- Detailed result reporting with confidence scores

## Test Plan
- [x] Unit tests for batch evaluation methods (9 test cases)
- [x] Tests for directory evaluation with pattern matching
- [x] Tests for CSV export functionality
- [x] Error handling tests
- [x] All existing tests pass (60 total tests)

## Usage Examples

```bash
# Evaluate all .txt files in a directory
llm-judge batch rubric.json -d ./documents/

# Evaluate specific files and save to CSV
llm-judge batch rubric.json -f doc1.txt doc2.txt -o results.csv

# Recursive search with pattern
llm-judge batch rubric.json -d ./docs/ -r --pattern "*.md" --max-concurrent 10

# Mock evaluation for testing
llm-judge batch rubric.json -d ./test-docs/ --mock --no-progress
```

🤖 Generated with [Claude Code](https://claude.ai/code)